### PR TITLE
Fix: truncate long product titles with ellipsis and add hover tooltip

### DIFF
--- a/src/app/components/Badge.tsx
+++ b/src/app/components/Badge.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Image from "next/image";
 import { BadgeData } from "../layout/Products";
+
 const Badge = ({ data }: { data: BadgeData }) => {
   return (
     <div className='m-2 cursor-pointer'>
@@ -16,7 +17,9 @@ const Badge = ({ data }: { data: BadgeData }) => {
         />
       </div>
       <div className='p-2 rounded-b-xl bg-main-color'>
-        <h3 className='text-center text-white'>{data.title}</h3>
+        <h3 className='text-center text-white truncate' title={data.title}>
+          {data.title}
+        </h3>
       </div>
     </div>
   );


### PR DESCRIPTION
## Fix: Truncate long product titles

### Changes
- Added `truncate` class to product title in Badge component to prevent text overflow
- Added `title` attribute to show full text on hover

### Problem
Long product titles were wrapping to multiple lines, causing inconsistent card heights across the grid.

### Solution
Titles now display on a single line with ellipsis (...) for overflow text. Users can hover to see the full title.