### PR TITLE
fix: handle escaped line breaks in TextWithBreaks component

### DIFF
--- a/src/app/components/TextWithBreaks.tsx
+++ b/src/app/components/TextWithBreaks.tsx
@@ -1,21 +1,25 @@
 import React from "react";
 
 const TextWithBreaks = ({ text }: { text: string }) => {
-  let textArray = text.split(/\r\n/g);
-  if (textArray.length < 2) {
-    textArray = text.split(/\n/g);
-  }
+  // Handle both actual line breaks and escaped line breaks from JSON
+  const textArray = text
+    .split(/\\r\\n|\\n|\r\n|\n/g);
 
   return (
     <>
       {textArray.map((item, id) => {
-        if (item === "")
-          return (
-            <React.Fragment key={id}>
-              <br></br>
-            </React.Fragment>
-          );
-        return item;
+        const trimmedItem = item.trim();
+        
+        if (trimmedItem === "") {
+          return <br key={id} />;
+        }
+        
+        return (
+          <React.Fragment key={id}>
+            {trimmedItem}
+            <br />
+          </React.Fragment>
+        );
       })}
     </>
   );


### PR DESCRIPTION
## Fix line break detection in TextWithBreaks component

Updates the regex pattern to handle escaped line break characters (`\r\n`, `\n`) from API responses.

**Changes:**
- Support both escaped and literal line breaks
- Trim whitespace for cleaner display
- Simplify rendering logic

**Fixes:** Text from API with escaped line breaks now displays correctly with proper formatting.